### PR TITLE
chore(infra): retire Vercel doc-drift, repoint legacy git identities

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Mao Nakamoto <41178744+maonakamoto@users.noreply.github.com> G <41178744+g-but@users.noreply.github.com>
+Mao Nakamoto <41178744+maonakamoto@users.noreply.github.com> g-but <41178744+g-but@users.noreply.github.com>
+Mao Nakamoto <41178744+maonakamoto@users.noreply.github.com> Your Name <your.email@example.com>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Connecting Zurich residents with certified repair shops through government-subsi
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6.svg)](https://www.typescriptlang.org/)
 [![Next.js](https://img.shields.io/badge/Next.js-15-000.svg)](https://nextjs.org/)
-[![Live](https://img.shields.io/badge/Live-reparaturbonus--zh.vercel.app-green.svg)](https://reparaturbonus-zh.vercel.app)
+[![Live](https://img.shields.io/badge/Live-reparaturbonus.orangecat.ch-green.svg)](https://reparaturbonus.orangecat.ch)
 
 ## What It Does
 
@@ -80,7 +80,7 @@ Three enums enforce domain constraints at the database level:
 | Database | PostgreSQL + Prisma 6 |
 | Auth | NextAuth.js, JWT, bcryptjs |
 | Styling | Tailwind CSS 4 |
-| Deployment | Vercel |
+| Deployment | Self-hosted (Hetzner, Caddy, Next.js standalone) |
 
 ---
 
@@ -95,7 +95,7 @@ Three enums enforce domain constraints at the database level:
 ### Setup
 
 ```bash
-git clone https://github.com/g-but/reparaturbonus-zh.git
+git clone https://github.com/maonakamoto/reparaturbonus-zh.git
 cd reparaturbonus-zh
 cp .env.example .env.local    # configure DATABASE_URL, NEXTAUTH_SECRET
 npm install


### PR DESCRIPTION
Docs/config-only cleanup. No app logic touched. App is LIVE — verified changes are documentation/metadata only.

## What
The self-host migration landed in `f36c7c5` (Vercel/Neon/Supabase exit, 2026-06-12) but the README still advertised Vercel. This closes the doc-drift.

- **README Live badge** → `reparaturbonus.orangecat.ch` (was `reparaturbonus-zh.vercel.app`)
- **README Tech Stack → Deployment** → `Self-hosted (Hetzner, Caddy, Next.js standalone)` (was `Vercel`)
- **README clone URL** → `maonakamoto` (was stale `g-but`)
- **`.mailmap`** added — collapses legacy authors (`G`, `g-but`, `Your Name`) to `Mao Nakamoto`

## Not touched
- Self-hosted Postgres / Prisma config — correct, left as-is
- App logic, env vars, schema — untouched
- Local-only untracked artifacts (`.vercel/` dir, `.claude/settings.local.json`) — not in repo; removed `.vercel/` locally as hygiene

🤖 Generated with [Claude Code](https://claude.com/claude-code)