### PR TITLE
ci: add golden verify floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+# Golden CI floor — see dotfiles/templates/ci/README.md.
+# reparaturbonus-zh: npm + Prisma, no test suite yet. Floor = verify
+# (lint + typecheck) — real signal that never ran before. Prisma has no
+# postinstall, so the client is generated before typecheck needs its types.
+# Build is deferred (prisma generate + next build needs DB/env); add it + a test
+# suite as follow-ups.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      DATABASE_URL: postgres://ci:ci@localhost:5432/ci
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Prisma generate (types for typecheck)
+        run: npx prisma generate
+
+      # SSOT: lint + typecheck, defined once in package.json `verify`.
+      - name: Verify
+        run: npm run verify

--- a/package.json
+++ b/package.json
@@ -7,10 +7,13 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "verify": "npm run lint && npm run typecheck",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
     "db:seed": "tsx prisma/seed.ts",
+    "db:upsert-shops": "tsx prisma/upsert-shops.ts",
     "db:studio": "prisma studio",
     "setup": "npm run db:generate && npm run db:push && npm run db:seed"
   },


### PR DESCRIPTION
## Rung 4 — propagate the golden floor

Adds a `verify` script + CI (install → prisma generate → verify) so this repo's `main` gets the same self-defending floor as the rest. Real signal it never had. Verified green locally first.

Deferred (documented in the workflow): build/e2e where non-hermetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)