### PR TITLE
ci: gate build in CI + add AGENTS.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
 # Golden CI floor — see dotfiles/templates/ci/README.md.
-# reparaturbonus-zh: npm + Prisma, no test suite yet. Floor = verify
-# (lint + typecheck) — real signal that never ran before. Prisma has no
-# postinstall, so the client is generated before typecheck needs its types.
-# Build is deferred (prisma generate + next build needs DB/env); add it + a test
-# suite as follow-ups.
+# reparaturbonus-zh: npm + Prisma, no test suite yet. Gate = verify
+# (lint + typecheck) + a full production build. Prisma has no postinstall, so
+# the client is generated before typecheck needs its types. The build is
+# hermetic: DB-backed pages (/admin, /dashboard) are `force-dynamic` and public
+# pages fetch client-side, so `next build` needs no live DB — a dummy
+# DATABASE_URL is enough. A test suite remains a follow-up (not warranted yet).
 name: CI
 
 on:
@@ -40,3 +41,12 @@ jobs:
       # SSOT: lint + typecheck, defined once in package.json `verify`.
       - name: Verify
         run: npm run verify
+
+      # Full production build. `npm run build` = prisma generate + next build.
+      # Hermetic: no live DB needed (dummy DATABASE_URL above). NEXTAUTH_* are
+      # dummies just to satisfy config resolution during the build.
+      - name: Build
+        env:
+          NEXTAUTH_SECRET: ci-dummy-secret
+          NEXTAUTH_URL: http://localhost:3000
+        run: npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md
+
+Guide for agents (and humans) working in this repo. Keep changes additive and
+respect the SSOT/DRY/SoC principles in `.claude/CLAUDE.md`.
+
+## What this is
+
+Reparaturbonus Zürich — a Next.js app connecting Zürich residents with certified
+repair shops and issuing government-subsidized bonus codes (repair instead of
+replace). See `README.md` for the product overview.
+
+## Stack
+
+| Layer | Technology |
+|-------|------------|
+| Framework | Next.js 15 (App Router, Turbopack, `output: "standalone"`) |
+| Language | TypeScript 5 (strict) |
+| Database | PostgreSQL + Prisma 6 |
+| Auth | NextAuth.js (credentials, JWT, bcryptjs) |
+| Styling | Tailwind CSS 4 |
+| Deploy | Self-hosted (Hetzner, Caddy) — `reparaturbonus.orangecat.ch` |
+
+## Commands
+
+```bash
+npm run dev        # dev server (Turbopack)
+npm run verify     # SSOT gate: lint + typecheck — run before every commit
+npm run build      # prisma generate + next build (hermetic, no live DB needed)
+npm run setup      # db:generate + db:push + db:seed (needs a live DATABASE_URL)
+```
+
+`npm run verify` is the single source of truth for "is this change OK". CI
+(`.github/workflows/ci.yml`) runs `prisma generate` then `npm run verify`, and
+gates `npm run build` on top. Green verify + build locally ⇒ green CI.
+
+## Prisma
+
+- Schema (SSOT for models/types): `prisma/schema.prisma` — 8 models, 3 enums.
+- Migrations: `prisma/migrations/` (`prisma migrate dev` to add; never edit
+  applied migrations).
+- Seed / data helpers: `prisma/seed.ts`, `prisma/upsert-shops.ts`,
+  `prisma/data/`.
+- Client is generated via `prisma generate` (no `postinstall` hook) — run it
+  before typecheck/build so generated types exist.
+
+## Build hermeticity
+
+`next build` does not touch a live database: DB-backed pages (`/admin`,
+`/dashboard`) are `export const dynamic = 'force-dynamic'`, and public pages
+fetch from API routes client-side. A dummy `DATABASE_URL` is enough to build.
+Note: `next.config.ts` sets `eslint.ignoreDuringBuilds` and
+`typescript.ignoreBuildErrors`, so the build does NOT re-check lint/types — that
+is why `verify` runs as its own gate.
+
+## Environment
+
+Copy `.env.example` → `.env.local` and set `DATABASE_URL`, `NEXTAUTH_SECRET`,
+`NEXTAUTH_URL`. Never commit `.env*` files or print secrets.
+
+## Conventions
+
+- Constants are SSOT: `src/lib/constants/` (routes, categories). No hardcoded
+  strings/amounts in components.
+- Bonus logic lives in `src/lib/bonus-codes.ts`.
+- API routes fall back to `src/lib/demo/` mock data when the DB is unavailable.


### PR DESCRIPTION
## What

Harden CI (additive, low-risk) for this Next.js 15 + Prisma app.

- **CI build gate**: add a full `npm run build` (`prisma generate && next build`) step after `verify` (lint + typecheck) in `.github/workflows/ci.yml`. This catches build-breaking regressions that lint/typecheck miss — especially since `next.config.ts` sets `eslint.ignoreDuringBuilds` and `typescript.ignoreBuildErrors`.
- **AGENTS.md**: new doc with stack, dev/verify/build commands, Prisma migrations location (`prisma/migrations/`), and a note on build hermeticity.

## Why the build is hermetic (no live DB in CI)

- `prisma generate` needs no database.
- DB-backed pages (`/admin`, `/dashboard`) are `export const dynamic = 'force-dynamic'` — not prerendered at build.
- Public pages fetch client-side from API routes; API routes are not executed at build time.
- README documents graceful degradation (fallback to mock data when the DB is down).

CI supplies a dummy `DATABASE_URL` (already set at job level) plus dummy `NEXTAUTH_*` to satisfy config resolution.

## Verification

- `npm run verify` passes locally (lint: no warnings/errors; typecheck clean).
- Local `next build` reached the compile stage with an unreachable DB and no DB error; the structural evidence above confirms hermeticity. **This PR's CI run executes the first full end-to-end build — that is the real gate.**

## Scope

Additive only. No tests, migrations, or deploy config changed. No other repo touched.