### PR TITLE
chore(infra): remove Vercel references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,6 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 
-# vercel
-.vercel
-
 # typescript
 *.tsbuildinfo
 next-env.d.ts


### PR DESCRIPTION
Vercel is fully decommissioned; every studio app now runs self-hosted on the Hetzner box "bitbaum" behind Caddy (reparaturbonus.orangecat.ch).

The only remaining reference was a dead Vercel artifact-ignore entry in `.gitignore` (`# vercel` / `.vercel`), removed here. No `vercel.json`, `.vercel/`, `VERCEL_*` env usage, or `*.vercel.app` URLs exist in the repo.

Typecheck: `npm run typecheck` passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)