### PR TITLE
ci: deploy on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Deploy
+
+# Push to main → deploy this app to bitbaum. All the logic lives in one
+# place: maonakamoto/fleetcrown/.github/workflows/selfhost-deploy.yml
+# (docs: docs/infrastructure/self-host-cd.md there). It waits for this
+# commit's own CI to go green before anything reaches the box.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    uses: maonakamoto/fleetcrown/.github/workflows/selfhost-deploy.yml@main
+    with:
+      app: reparaturbonus-zh
+    secrets: inherit


### PR DESCRIPTION
Wires this repo into the shared self-host CD pipeline (`maonakamoto/fleetcrown/.github/workflows/selfhost-deploy.yml`).

Deploys previously only ran from a **local pre-push hook**, so anything merged on GitHub never reached bitbaum. The shared workflow waits for this commit's CI to go green, pulls the runtime env from the box, builds, swaps atomically with auto-rollback, and verifies the public URL returns 2xx before reporting success.

Proven end-to-end on `sbb-lost-found` first: 2m20s, release symlink repointed to the merged SHA, site 200.