### PR TITLE
ci: allow manual redeploy via workflow_dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,10 @@ name: Deploy
 on:
   push:
     branches: [main]
+  # Redeploy the current main without inventing a commit. Re-running a failed
+  # deploy is NOT equivalent: a re-run reuses the original run's resolved
+  # reusable-workflow version, so a fix landed since then does not apply.
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
Re-running a failed deploy is **not** equivalent to a fresh run: GitHub reuses the original run's resolved version of the reusable workflow, so a fix landed in `fleetcrown` since then does not apply. This app sat waiting on a CI gate that had already been fixed.

`workflow_dispatch` makes a clean redeploy of current `main` possible without inventing a commit. Merging this also triggers the deploy that was stuck.