### PR TITLE
feat(meta): give the site a real social preview

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,9 +12,26 @@ import SessionProviderWrapper from "@/components/providers/session-provider";
 const geistSans = GeistSans;
 const geistMono = GeistMono;
 
+/**
+ * Where this site actually serves. Load-bearing for the social preview: Next
+ * resolves the generated og:image against `metadataBase`, and without it the
+ * tag is emitted as http://localhost:3000/opengraph-image — present, plausible,
+ * and unfetchable by every scraper. Falls back to the real host, not localhost.
+ */
+const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || "https://reparaturbonus.orangecat.ch";
+
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: "Reparaturbonus Zürich - Reparieren statt wegwerfen",
   description: "Finden Sie die beste Werkstatt in Zürich und nutzen Sie CHF 100 Reparaturbonus der Stadt. Nachhaltig, günstig und umweltfreundlich.",
+  openGraph: {
+    title: "Reparaturbonus Zürich — Reparieren statt wegwerfen",
+    description: "Die beste Werkstatt in Zürich finden und CHF 100 Reparaturbonus der Stadt nutzen.",
+    url: SITE_URL,
+    siteName: "Reparaturbonus Zürich",
+    type: "website",
+    locale: "de_CH",
+  },
   icons: {
     icon: [
       { url: "/logo/favicon.ico", sizes: "any" },

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,80 @@
+import { ImageResponse } from "next/og";
+
+/**
+ * Social preview card (1200x630 — the 1.91:1 size Slack, Telegram and the
+ * OpenGraph scrapers crop to). The site shipped no og:image, so every shared
+ * link rendered as a blank grey rectangle.
+ *
+ * Satori cannot read CSS custom properties, so the palette is repeated here as
+ * literals mirroring --primitive-blue-700 / --primitive-copper-500 /
+ * --primitive-paper in globals.css, which stays the source of truth.
+ */
+
+export const runtime = "edge";
+export const alt = "Reparaturbonus Zürich — Reparieren statt wegwerfen";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const BLUE = "#1B4A8F";
+const BLUE_DEEP = "#0F2E5C";
+const COPPER = "#C26B2D";
+const PAPER = "#F7F5F1";
+const STONE = "#6E665C";
+
+export default function OGImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          background: PAPER,
+          padding: "72px 80px",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+          <div style={{ width: 18, height: 18, borderRadius: 4, background: COPPER, display: "flex" }} />
+          <div
+            style={{
+              fontSize: 26,
+              letterSpacing: "0.18em",
+              textTransform: "uppercase",
+              color: BLUE,
+              fontWeight: 600,
+            }}
+          >
+            Reparaturbonus Zürich
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div
+            style={{
+              fontSize: 88,
+              fontWeight: 700,
+              letterSpacing: "-0.03em",
+              lineHeight: 1.04,
+              color: BLUE_DEEP,
+              maxWidth: 960,
+            }}
+          >
+            Reparieren statt wegwerfen
+          </div>
+          <div style={{ marginTop: 28, fontSize: 32, lineHeight: 1.35, color: STONE, maxWidth: 900 }}>
+            Die beste Werkstatt in Zürich finden und CHF 100 Reparaturbonus der Stadt nutzen.
+          </div>
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+          <div style={{ width: 64, height: 5, borderRadius: 999, background: COPPER, display: "flex" }} />
+          <div style={{ fontSize: 24, color: STONE }}>reparaturbonus.orangecat.ch</div>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}


### PR DESCRIPTION
Every link to this site currently shares as a **blank grey rectangle** — it ships no `og:image` at all.

Adds the Next file-convention card (`opengraph-image.tsx`, 1200x630 — the 1.91:1 size Slack, Telegram and the OpenGraph scrapers crop to), drawn in this site's own palette from `globals.css`.

**Also sets `metadataBase`, which is the load-bearing half.** Without it Next resolves the generated image to `http://localhost:3000/opengraph-image`: a tag that is present, looks configured, and is unfetchable by every scraper. The fallback is the real host, so a missing env var degrades to correct instead of to localhost.

Verified end-to-end on a sibling repo before porting: build, render, `200 image/png`, 1200x630, and `og:image` emitted as the absolute production URL. Local `tsc --noEmit` clean; CI does the build.

Part of a fleet-wide sweep — 10 of 15 sites shared blank, found by [FleetCrown Atlas](https://fleetcrown.orangecat.ch/atlas).