### PR TITLE
fix(a11y): the CTA fill could not carry white text

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,6 +22,12 @@
   --primitive-blue-50:  #EEF3FA;
 
   --primitive-copper-700: #9A4E1E;
+  /* 600 exists because 500 cannot carry white text: #C26B2D under white is
+     3.86:1, below the 4.5 AA floor, and it is the fill behind every primary
+     CTA ("Reparatur starten", "Jetzt kostenlos anmelden", "Registrieren").
+     #A85A24 is 5.06:1 and still visibly copper. 500 stays in the ramp for
+     fills and borders, where the floor is 3:1 and it passes. */
+  --primitive-copper-600: #A85A24;
   --primitive-copper-500: #C26B2D;
   --primitive-copper-50:  #FBF1E8;
 
@@ -44,7 +50,7 @@
   --color-brand-strong: var(--primitive-blue-900);
   --color-brand-soft:   var(--primitive-blue-50);
 
-  --color-action:        var(--primitive-copper-500);
+  --color-action:        var(--primitive-copper-600);
   --color-action-strong: var(--primitive-copper-700);
   --color-action-soft:   var(--primitive-copper-50);
 


### PR DESCRIPTION
Measured live: **white on #C26B2D is 3.86:1**, below the 4.5 AA floor. It is the fill behind every primary action on the site — `Reparatur starten`, `Jetzt kostenlos anmelden`, `Registrieren`.

`--color-action` now points at a new `--primitive-copper-600` (#A85A24, **5.06:1** under white) instead of copper-500. Still visibly copper, one step down. The hover already used copper-700, which is 6.03:1 — the pressed state was never the problem.

**copper-500 stays in the ramp on purpose.** It is fine as a fill or a border, where the floor is 3:1 and it passes; it is only wrong under white text. Removing it would have thrown away a usable brand step to fix a problem it does not have everywhere.

The `text-on-brand` token this site already had was pointing at white — correct in name and wrong in fact. A pairing only works once the background it names can actually carry it.

Found by the new fleet UI audit (`dotfiles scripts/ci/ui-defect-audit.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)